### PR TITLE
Use Hash as ID and add Nonce

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The intent of Supersig is to keep all approval and proposal actions on-chain, wi
 
 Supersig was written as part of the ETHNYC 2022 Hackathon. It uses Apeworx, Vyper, Pokt, and Privy who were among the awesome sponsors of the event.
 
+For an offline, EIP712-based multisig in vyper, also see [ricobank/multisig](https://github.com/ricobank/multisig)
+
 ### Setup
 Recommend using [miniconda](https://docs.conda.io/en/latest/miniconda.html)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,9 @@ from eth_abi import encode_abi as abi_encode
 
 @pytest.fixture(scope="session")
 def hash_proposal():
-    def hash_proposal(target, calldata, value):
+    def hash_proposal(target, calldata, value, nonce):
         return keccak(
-            abi_encode(["address", "bytes", "uint256"], [target, calldata, value])
+            abi_encode(["address", "bytes", "uint256", "uint256"], [target, calldata, value, nonce])
         )
 
     return hash_proposal
@@ -44,10 +44,10 @@ def supersig(deployer, owners, project, threshold):
 @pytest.fixture()
 def supersig_with_proposal(supersig, owners, hash_proposal):
     proposal_hash = hash_proposal(
-        "0x000000000000000000000000000000000000dead", HexBytes("0xbeaf"), 0
+        "0x000000000000000000000000000000000000dead", HexBytes("0xbeaf"), 0, 420
     )
-    supersig.propose(1, proposal_hash, sender=owners[0])
-    return supersig
+    supersig.approve(proposal_hash, sender=owners[0])
+    return supersig, proposal_hash
 
 
 @pytest.fixture()

--- a/tests/test_supersig.py
+++ b/tests/test_supersig.py
@@ -9,66 +9,71 @@ def test_init(supersig, owners, threshold):
         assert supersig.owners(i) == owner
 
 
-def test_proposal(supersig, owners, hash_proposal):
+def test_approve(supersig, owners, hash_proposal):
     target = "0x000000000000000000000000000000000000dead"
     calldata = HexBytes("0xbeaf")
     value = 0
-    proposal_hash = hash_proposal(target, calldata, value)
-    supersig.propose(1, proposal_hash, sender=owners[0])
-    assert supersig.proposals(1).hash == proposal_hash
+    nonce = 1337
+    proposal_hash = hash_proposal(target, calldata, value, nonce)
+    supersig.approve(proposal_hash, sender=owners[0])
+    assert supersig.proposals(proposal_hash).approvers[0] == owners[0]
+    assert supersig.approvals(proposal_hash) == 1
 
 
-def test_approval(supersig_with_proposal, owners):
-    supersig_with_proposal.approve(1, sender=owners[0])
-    assert supersig_with_proposal.approvals(1) == 1
+def test_additional_approval(supersig_with_proposal, owners):
+    supersig, proposal_hash = supersig_with_proposal
+    supersig.approve(proposal_hash, sender=owners[1])
+    assert supersig.approvals(proposal_hash) == 2
+    assert supersig.proposals(proposal_hash).approvers[1] == owners[1]
 
 
 def test_execute(supersig, test_target_contract, owners, hash_proposal):
-    ## "set_magic_number(69)" courtesy of cast :)
     target = test_target_contract.address
+    ## "set_magic_number(69)" courtesy of cast :)
     calldata = HexBytes(
         "0x70a5aa210000000000000000000000000000000000000000000000000000000000000045"
     )
     value = 0
-    proposal_hash = hash_proposal(target, calldata, value)
-    supersig.propose(2, proposal_hash, sender=owners[0])
+    nonce = 1337
+    proposal_hash = hash_proposal(target, calldata, value, nonce)
+    supersig.approve(proposal_hash, sender=owners[0])
 
-    ## Approve three times
-    supersig.approve(2, sender=owners[0])
-    supersig.approve(2, sender=owners[1])
-    supersig.approve(2, sender=owners[2])
+    ## Approve two more times
+    supersig.approve(proposal_hash, sender=owners[1])
+    supersig.approve(proposal_hash, sender=owners[2])
 
     ## Execute
-    supersig.execute(2, target, calldata, value, sender=owners[0])
+    supersig.execute(target, calldata, value, nonce, sender=owners[0])
 
     ## Check that the proposal was executed
     assert test_target_contract.magic_number() == 0x45
 
 
 def test_revoke(supersig_with_proposal, owners):
-    supersig_with_proposal.approve(1, sender=owners[0])
-    assert supersig_with_proposal.approvals(1) == 1
-    supersig_with_proposal.revoke(1, sender=owners[0])
-    assert supersig_with_proposal.approvals(1) == 0
+    supersig, proposal_hash = supersig_with_proposal
+    # Fixture already has one approval by owner[0]
+    supersig.revoke(proposal_hash, sender=owners[0])
+    assert supersig.approvals(proposal_hash) == 0
 
     ## should be able to approve again
-    supersig_with_proposal.approve(1, sender=owners[0])
+    supersig.approve(proposal_hash, sender=owners[0])
+    assert supersig.approvals(proposal_hash) == 1
 
 
-def test_withdraw(supersig, owners, not_owner, hash_proposal):
+def test_send_value(supersig, owners, not_owner, hash_proposal):
     target = not_owner.address
     calldata = HexBytes("0x0")
     value = 42
-    proposal_hash = hash_proposal(target, calldata, value)
+    nonce = 1337
+    proposal_hash = hash_proposal(target, calldata, value, nonce)
     owners[0].transfer(supersig, value=42)
     assert supersig.balance == 42
-    supersig.propose(3, proposal_hash, sender=owners[0])
-    supersig.approve(3, sender=owners[0])
-    supersig.approve(3, sender=owners[1])
-    supersig.approve(3, sender=owners[2])
+    supersig.approve(proposal_hash, sender=owners[0])
+    supersig.approve(proposal_hash, sender=owners[1])
+    supersig.approve(proposal_hash, sender=owners[2])
 
     prev_balance = not_owner.balance
-    supersig.execute(3, target, calldata, value, sender=owners[0])
+    supersig.execute(target, calldata, value, nonce, sender=owners[0])
     assert not_owner.balance == prev_balance + 42
 
 
@@ -79,42 +84,36 @@ def test_deploy_with_value(owners, project):
     )
     assert contract.balance == 1
 
-
-def test_fail_propose_already_exists(supersig_with_proposal, owners):
-    with ape.reverts():
-        supersig_with_proposal.propose(1, keccak(HexBytes("0x0")), sender=owners[0])
-
-
 def test_fail_approval_bad_caller(supersig_with_proposal, not_owner):
-    with ape.reverts():
-        supersig_with_proposal.approve(1, sender=not_owner)
+    supersig, proposal_hash = supersig_with_proposal
+    with ape.reverts("Only owners can approve proposals"):
+        supersig.approve(proposal_hash, sender=not_owner)
 
 
 def test_fail_approve_twice(supersig_with_proposal, owners):
-    ## approve once
-    supersig_with_proposal.approve(1, sender=owners[0])
-    ## try to approve again
-    with ape.reverts():
-        supersig_with_proposal.approve(1, sender=owners[0])
+    supersig, proposal_hash = supersig_with_proposal
+    ## try to approve again (already approved once in fixture)
+    with ape.reverts("You have already approved this proposal"):
+        supersig.approve(proposal_hash, sender=owners[0])
 
 
-def test_fail_execute_too_few_approvals(supersig_with_proposal, owners):
-    ## approve once
-    supersig_with_proposal.approve(1, sender=owners[0])
-    ## try to approve again
+def test_fail_execute_too_few_approvals(supersig, owners, hash_proposal):
     target = "0x000000000000000000000000000000000000dead"
-    calldata = HexBytes("0xbeaf")
+    calldata = HexBytes("0x0")
     value = 0
+    nonce = 1337
+    proposal_hash = hash_proposal(target, calldata, value, nonce)
+    supersig.approve(proposal_hash, sender=owners[0])
     with ape.reverts("Proposal has not been approved by the minimum number of owners"):
-        supersig_with_proposal.execute(1, target, calldata, value, sender=owners[1])
+        supersig.execute(target, calldata, value, nonce, sender=owners[0])
 
 
 def test_fail_execute_does_not_exist(supersig, owners):
     with ape.reverts("Proposal has not been approved by the minimum number of owners"):
         supersig.execute(
-            0,
             "0x000000000000000000000000000000000000dead",
             HexBytes("0x0"),
+            0,
             0,
             sender=owners[0],
         )
@@ -124,29 +123,30 @@ def test_fail_execute_twice(supersig, owners, not_owner, hash_proposal):
     target = not_owner.address
     calldata = HexBytes("0x0")
     value = 42
-    proposal_hash = hash_proposal(target, calldata, value)
+    nonce = 1337
+    proposal_hash = hash_proposal(target, calldata, value, nonce)
     owners[0].transfer(supersig, value=42)
     assert supersig.balance == 42
-    supersig.propose(3, proposal_hash, sender=owners[0])
-    supersig.approve(3, sender=owners[0])
-    supersig.approve(3, sender=owners[1])
-    supersig.approve(3, sender=owners[2])
+    supersig.approve(proposal_hash, sender=owners[0])
+    supersig.approve(proposal_hash, sender=owners[1])
+    supersig.approve(proposal_hash, sender=owners[2])
 
     prev_balance = not_owner.balance
-    supersig.execute(3, target, calldata, value, sender=owners[0])
+    supersig.execute(target, calldata, value, nonce, sender=owners[0])
     assert not_owner.balance == prev_balance + 42
     prev_balance = not_owner.balance
 
     ## try to execute again
     with ape.reverts("Proposal has not been approved by the minimum number of owners"):
-        supersig.execute(3, target, calldata, value, sender=owners[0])
+        supersig.execute(target, calldata, value, nonce, sender=owners[0])
 
     assert not_owner.balance == prev_balance
 
 
-def test_fail_revoke_no_approval(supersig, owners):
-    with ape.reverts():
-        supersig.revoke(1, sender=owners[0])
+def test_fail_revoke_no_approval(supersig_with_proposal, owners):
+    supersig, proposal_hash = supersig_with_proposal
+    with ape.reverts("No approval to revoke"):
+        supersig.revoke(proposal_hash, sender=owners[1])
 
 
 def test_fail_calldata_doesnt_match_hash(supersig, owners, hash_proposal):
@@ -154,14 +154,14 @@ def test_fail_calldata_doesnt_match_hash(supersig, owners, hash_proposal):
     target = "0x000000000000000000000000000000000000dead"
     calldata = HexBytes("0xbeaf")
     value = 0
-    proposal_hash = hash_proposal(target, calldata, value)
-    supersig.propose(2, proposal_hash, sender=owners[0])
+    nonce = 1337
+    proposal_hash = hash_proposal(target, calldata, value, nonce)
 
     ## Approve three times
-    supersig.approve(2, sender=owners[0])
-    supersig.approve(2, sender=owners[1])
-    supersig.approve(2, sender=owners[2])
+    supersig.approve(proposal_hash, sender=owners[0])
+    supersig.approve(proposal_hash, sender=owners[1])
+    supersig.approve(proposal_hash, sender=owners[2])
 
     ## Execute
-    with ape.reverts("Proposal hash does not match provided data"):
-        supersig.execute(2, target, calldata, 420, sender=owners[0])
+    with ape.reverts("Proposal has not been approved by the minimum number of owners"):
+        supersig.execute(target, calldata, value, 1338, sender=owners[0])


### PR DESCRIPTION
Makes some changes

- Uses proposal hash as ID instead of having a user-defined ID
- Hash now includes a nonce, which is a uint256, and is defined as `keccak256(target . calldata . value . nonce)`

Note this means that there is no longer the concept of "proposing". You simply approve a hash.
Tests updated as well.
TODO:

- [ ] Updated README